### PR TITLE
Disable remote reads for bank balances in forking mode

### DIFF
--- a/x/thorchain/forking/client.go
+++ b/x/thorchain/forking/client.go
@@ -156,6 +156,9 @@ func (c *remoteClient) fetchViaGRPC(ctx context.Context, storeKey string, key []
 	lkey := strings.ToLower(keyStr)
 	lstore := strings.ToLower(storeKey)
 
+	if lstore == "bank" {
+		return nil, nil
+	}
 
 	if lstore == strings.ToLower(wasmtypes.StoreKey) {
 		if len(key) == 0 {

--- a/x/thorchain/forking/store.go
+++ b/x/thorchain/forking/store.go
@@ -45,6 +45,10 @@ func NewForkingKVStore(
 }
 
 func (f *forkingKVStore) shouldAllowRemoteFetch() bool {
+	if f.storeKey == "bank" {
+		return false
+	}
+
 	if f.service.IsGenesisMode() {
 		return false
 	}
@@ -52,14 +56,14 @@ func (f *forkingKVStore) shouldAllowRemoteFetch() bool {
 	if f.storeKey == "wasm" {
 		return true
 	}
-	if f.storeKey == "thorchain" || f.storeKey == "bank" || f.storeKey == "auth" {
+	if f.storeKey == "thorchain" || f.storeKey == "auth" {
 		return true
 	}
 
 	if f.sdkCtx != nil {
 		if f.sdkCtx.IsCheckTx() || f.sdkCtx.IsReCheckTx() {
 			fmt.Printf("[forking] checking tx\n")
-			if f.storeKey == "acc" || f.storeKey == "auth" || f.storeKey == "bank" {
+			if f.storeKey == "acc" || f.storeKey == "auth" {
 				return true
 			}
 			return false


### PR DESCRIPTION
### **User description**
# Disable remote reads for bank balances in forking mode

## Summary
Fixes the hanging issue when running `thornode query bank balances <address>` in forking mode by making bank store reads strictly local-only. The forking implementation was previously attempting to fetch balance data from the remote mainnet via gRPC, which caused queries to hang. This change ensures that balance queries only use local database state and never attempt remote fetches.

**Changes:**
- Modified `shouldAllowRemoteFetch()` in `forking/store.go` to always return `false` for `storeKey == "bank"`
- Added defensive guard in `fetchViaGRPC()` in `forking/client.go` to no-op for bank store keys
- Removed bank from CheckTx/ReCheckTx remote fetch allowlist since balances should be local-only

## Review & Testing Checklist for Human
- [ ] **Test balance queries work and don't hang**: Run `thornode query bank balances <address>` in forking mode and verify it returns promptly with correct local balance data
- [ ] **Verify transaction validation still works**: Submit transactions and ensure CheckTx/ReCheckTx flows can still validate properly without remote bank access
- [ ] **Check other bank store operations**: Verify that other bank-related functionality (transfers, etc.) still works correctly with local-only bank store access

### Notes
**Link to Devin run:** https://app.devin.ai/sessions/0b323a13287f4954866e09d7212be2d1  
**Requested by:** @tiljrd

This change implements the requirement that "for balances it should actually never use mainnet data but just keep a local record of address balances." The dual guards provide defense-in-depth but the primary enforcement is at the store level via `shouldAllowRemoteFetch()`.

⚠️ **Important**: This PR has not been tested yet in the actual kurtosis environment - that testing was planned as the next step after this code change.


___

### **PR Type**
Bug fix


___

### **Description**
- Disable remote reads for bank balances in forking mode

- Add defensive guard in gRPC fetch function

- Remove bank from CheckTx remote fetch allowlist

- Ensure balance queries use local-only database state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bank Store Query"] --> B["shouldAllowRemoteFetch()"]
  B --> C["Return false for bank"]
  C --> D["Local Database Only"]
  E["fetchViaGRPC()"] --> F["Bank Store Guard"]
  F --> G["Return nil for bank"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>store.go</strong><dd><code>Disable bank store remote fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x/thorchain/forking/store.go

<ul><li>Add early return <code>false</code> for bank store in <code>shouldAllowRemoteFetch()</code><br> <li> Remove "bank" from CheckTx/ReCheckTx remote fetch allowlist<br> <li> Remove "bank" from general remote fetch allowlist</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/9/files#diff-cf62fe669bced699cd48fb52713375ea8d140c10798aa5bad17d0fbf042d17fc">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.go</strong><dd><code>Add bank store guard in gRPC client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

x/thorchain/forking/client.go

<ul><li>Add defensive guard to return <code>nil</code> for bank store keys<br> <li> Prevent gRPC fetches for bank-related data</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/9/files#diff-eda7bf113761398d2cea9d1e1ecf641b951f58f3e5df01085b7ae6e86e145ceb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

