### PR TITLE
wasm: runtime env flag to allow permissionless store/instantiate (THOR_WASM_PERMISSION_MODE)

### DIFF
--- a/x/bloctopus/wasm_manager.go
+++ b/x/bloctopus/wasm_manager.go
@@ -42,6 +42,9 @@ func (m WasmMgrPermissionless) InstantiateContract(
 	label string,
 	deposit sdk.Coins,
 ) (sdk.AccAddress, []byte, error) {
+	if err := m.maybePin(ctx, codeID); err != nil {
+		return nil, nil, err
+	}
 	return m.permKeeper().Instantiate(ctx, codeID, creator, admin, initMsg, label, deposit)
 }
 
@@ -55,6 +58,9 @@ func (m WasmMgrPermissionless) InstantiateContract2(
 	salt []byte,
 	fixMsg bool,
 ) (sdk.AccAddress, []byte, error) {
+	if err := m.maybePin(ctx, codeID); err != nil {
+		return nil, nil, err
+	}
 	return m.permKeeper().Instantiate2(ctx, codeID, creator, admin, initMsg, label, deposit, salt, fixMsg)
 }
 
@@ -73,7 +79,20 @@ func (m WasmMgrPermissionless) MigrateContract(
 	newCodeID uint64,
 	msg []byte,
 ) ([]byte, error) {
-	return m.permKeeper().Migrate(ctx, contractAddress, caller, newCodeID, msg)
+	if err := m.maybePin(ctx, newCodeID); err != nil {
+		return nil, err
+	}
+	data, err := m.permKeeper().Migrate(ctx, contractAddress, caller, newCodeID, msg)
+	if err != nil {
+		return nil, err
+	}
+	contractInfo := m.wasmKeeper.GetContractInfo(ctx, contractAddress)
+	if contractInfo != nil {
+		if err := m.maybeUnpin(ctx, contractInfo.CodeID); err != nil {
+			return nil, err
+		}
+	}
+	return data, nil
 }
 
 func (m WasmMgrPermissionless) SudoContract(
@@ -104,4 +123,32 @@ func (m WasmMgrPermissionless) getCodeInfo(ctx cosmos.Context, id uint64) (*wasm
 		return nil, wasmtypes.ErrNotFound
 	}
 	return codeInfo, nil
+}
+
+func (m WasmMgrPermissionless) maybePin(ctx cosmos.Context, codeId uint64) error {
+	var instanceCount int
+	m.wasmKeeper.IterateContractsByCode(ctx, codeId, func(address sdk.AccAddress) bool {
+		instanceCount++
+		return true
+	})
+	if instanceCount == 0 {
+		if err := m.permKeeper().PinCode(ctx, codeId); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m WasmMgrPermissionless) maybeUnpin(ctx cosmos.Context, codeId uint64) error {
+	var instanceCount int
+	m.wasmKeeper.IterateContractsByCode(ctx, codeId, func(address sdk.AccAddress) bool {
+		instanceCount++
+		return true
+	})
+	if instanceCount == 0 {
+		if err := m.permKeeper().UnpinCode(ctx, codeId); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/x/bloctopus/wasm_manager.go
+++ b/x/bloctopus/wasm_manager.go
@@ -7,23 +7,18 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"gitlab.com/thorchain/thornode/v3/common/cosmos"
-	"gitlab.com/thorchain/thornode/v3/x/thorchain"
 	"gitlab.com/thorchain/thornode/v3/x/thorchain/keeper"
 )
-
-var _ thorchain.WasmManager = &WasmMgrPermissionless{}
 
 type WasmMgrPermissionless struct {
 	keeper     keeper.Keeper
 	wasmKeeper wasmkeeper.Keeper
-	eventMgr   thorchain.EventManager
 }
 
-func NewWasmMgrPermissionless(k keeper.Keeper, wk wasmkeeper.Keeper, ev thorchain.EventManager) (*WasmMgrPermissionless, error) {
+func NewWasmMgrPermissionless(k keeper.Keeper, wk wasmkeeper.Keeper) (*WasmMgrPermissionless, error) {
 	return &WasmMgrPermissionless{
 		keeper:     k,
 		wasmKeeper: wk,
-		eventMgr:   ev,
 	}, nil
 }
 

--- a/x/bloctopus/wasm_manager.go
+++ b/x/bloctopus/wasm_manager.go
@@ -1,0 +1,112 @@
+package bloctopus
+
+import (
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"gitlab.com/thorchain/thornode/v3/common/cosmos"
+	"gitlab.com/thorchain/thornode/v3/x/thorchain"
+	"gitlab.com/thorchain/thornode/v3/x/thorchain/keeper"
+)
+
+var _ thorchain.WasmManager = &WasmMgrPermissionless{}
+
+type WasmMgrPermissionless struct {
+	keeper     keeper.Keeper
+	wasmKeeper wasmkeeper.Keeper
+	eventMgr   thorchain.EventManager
+}
+
+func NewWasmMgrPermissionless(k keeper.Keeper, wk wasmkeeper.Keeper, ev thorchain.EventManager) (*WasmMgrPermissionless, error) {
+	return &WasmMgrPermissionless{
+		keeper:     k,
+		wasmKeeper: wk,
+		eventMgr:   ev,
+	}, nil
+}
+
+func (m WasmMgrPermissionless) permKeeper() *wasmkeeper.PermissionedKeeper {
+	return wasmkeeper.NewDefaultPermissionKeeper(m.wasmKeeper)
+}
+
+func (m WasmMgrPermissionless) StoreCode(
+	ctx cosmos.Context,
+	creator sdk.AccAddress,
+	wasmCode []byte,
+) (codeID uint64, checksum []byte, err error) {
+	return m.permKeeper().Create(ctx, creator, wasmCode, nil)
+}
+
+func (m WasmMgrPermissionless) InstantiateContract(
+	ctx cosmos.Context,
+	codeID uint64,
+	creator, admin sdk.AccAddress,
+	initMsg []byte,
+	label string,
+	deposit sdk.Coins,
+) (sdk.AccAddress, []byte, error) {
+	return m.permKeeper().Instantiate(ctx, codeID, creator, admin, initMsg, label, deposit)
+}
+
+func (m WasmMgrPermissionless) InstantiateContract2(
+	ctx cosmos.Context,
+	codeID uint64,
+	creator, admin sdk.AccAddress,
+	initMsg []byte,
+	label string,
+	deposit sdk.Coins,
+	salt []byte,
+	fixMsg bool,
+) (sdk.AccAddress, []byte, error) {
+	return m.permKeeper().Instantiate2(ctx, codeID, creator, admin, initMsg, label, deposit, salt, fixMsg)
+}
+
+func (m WasmMgrPermissionless) ExecuteContract(
+	ctx cosmos.Context,
+	contractAddr, senderAddr sdk.AccAddress,
+	msg []byte,
+	coins sdk.Coins,
+) ([]byte, error) {
+	return m.permKeeper().Execute(ctx, contractAddr, senderAddr, msg, coins)
+}
+
+func (m WasmMgrPermissionless) MigrateContract(
+	ctx cosmos.Context,
+	contractAddress, caller sdk.AccAddress,
+	newCodeID uint64,
+	msg []byte,
+) ([]byte, error) {
+	return m.permKeeper().Migrate(ctx, contractAddress, caller, newCodeID, msg)
+}
+
+func (m WasmMgrPermissionless) SudoContract(
+	ctx cosmos.Context,
+	contractAddress, _ sdk.AccAddress,
+	msg []byte,
+) ([]byte, error) {
+	return m.permKeeper().Sudo(ctx, contractAddress, msg)
+}
+
+func (m WasmMgrPermissionless) UpdateAdmin(
+	ctx cosmos.Context,
+	contractAddress, sender, newAdmin sdk.AccAddress,
+) ([]byte, error) {
+	return nil, m.permKeeper().UpdateContractAdmin(ctx, contractAddress, sender, newAdmin)
+}
+
+func (m WasmMgrPermissionless) ClearAdmin(
+	ctx cosmos.Context,
+	contractAddress, sender sdk.AccAddress,
+) ([]byte, error) {
+	return nil, m.permKeeper().ClearContractAdmin(ctx, contractAddress, sender)
+}
+
+func (m WasmMgrPermissionless) getCodeInfo(ctx cosmos.Context, id uint64) (*wasmtypes.CodeInfo, error) {
+	codeInfo := m.wasmKeeper.GetCodeInfo(ctx, id)
+	if codeInfo == nil {
+		return nil, wasmtypes.ErrNotFound
+	}
+	return codeInfo, nil
+}

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -18,6 +18,14 @@ import (
 	"gitlab.com/thorchain/thornode/v3/common/wasmpermissions"
 )
 
+var wasmPermMode = func() string {
+	m := strings.ToLower(strings.TrimSpace(os.Getenv("THOR_WASM_PERMISSION_MODE")))
+	if m == "permissionless" {
+		return "permissionless"
+	}
+	return ""
+}()
+
 var _ WasmManager = &WasmMgrVCUR{}
 
 // WasmMgrVCUR is VCUR implementation of slasher
@@ -339,14 +347,14 @@ func (m WasmMgrVCUR) checkChecksumHalt(ctx cosmos.Context, checksum []byte) erro
 }
 
 func (m WasmMgrVCUR) permissionedKeeper() *wasmkeeper.PermissionedKeeper {
-	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+	if wasmPermMode == "permissionless" {
 		return wasmkeeper.NewDefaultPermissionKeeper(m.wasmKeeper)
 	}
 	return wasmkeeper.NewGovPermissionKeeper(m.wasmKeeper)
 }
 
 func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) error {
-	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+	if wasmPermMode == "permissionless" {
 		return nil
 	}
 	err := m.checkActor(ctx, actor)
@@ -366,7 +374,7 @@ func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) 
 }
 
 func (m WasmMgrVCUR) checkCanInstantiate(ctx cosmos.Context, actor cosmos.AccAddress) error {
-	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+	if wasmPermMode == "permissionless" {
 		return nil
 	}
 	err := m.checkActor(ctx, actor)

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -2,6 +2,7 @@ package thorchain
 
 import (
 	"encoding/base32"
+	"strings"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -346,6 +346,9 @@ func (m WasmMgrVCUR) permissionedKeeper() *wasmkeeper.PermissionedKeeper {
 }
 
 func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) error {
+	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+		return nil
+	}
 	err := m.checkActor(ctx, actor)
 	if err != nil {
 		return err
@@ -363,6 +366,9 @@ func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) 
 }
 
 func (m WasmMgrVCUR) checkCanInstantiate(ctx cosmos.Context, actor cosmos.AccAddress) error {
+	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+		return nil
+	}
 	err := m.checkActor(ctx, actor)
 	if err != nil {
 		return err

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -3,6 +3,7 @@ package thorchain
 import (
 	"encoding/base32"
 	"strings"
+	"os"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -338,6 +339,9 @@ func (m WasmMgrVCUR) checkChecksumHalt(ctx cosmos.Context, checksum []byte) erro
 }
 
 func (m WasmMgrVCUR) permissionedKeeper() *wasmkeeper.PermissionedKeeper {
+	if mode := os.Getenv("THOR_WASM_PERMISSION_MODE"); mode == "permissionless" {
+		return wasmkeeper.NewDefaultPermissionKeeper(m.wasmKeeper)
+	}
 	return wasmkeeper.NewGovPermissionKeeper(m.wasmKeeper)
 }
 

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -16,13 +16,6 @@ import (
 	"gitlab.com/thorchain/thornode/v3/common/wasmpermissions"
 )
 
-var wasmPermMode = func() string {
-	m := strings.ToLower(strings.TrimSpace(os.Getenv("THOR_WASM_PERMISSION_MODE")))
-	if m == "permissionless" {
-		return "permissionless"
-	}
-	return ""
-}()
 
 var _ WasmManager = &WasmMgrVCUR{}
 

--- a/x/thorchain/manager_wasm_current.go
+++ b/x/thorchain/manager_wasm_current.go
@@ -2,8 +2,6 @@ package thorchain
 
 import (
 	"encoding/base32"
-	"strings"
-	"os"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -347,16 +345,10 @@ func (m WasmMgrVCUR) checkChecksumHalt(ctx cosmos.Context, checksum []byte) erro
 }
 
 func (m WasmMgrVCUR) permissionedKeeper() *wasmkeeper.PermissionedKeeper {
-	if wasmPermMode == "permissionless" {
-		return wasmkeeper.NewDefaultPermissionKeeper(m.wasmKeeper)
-	}
 	return wasmkeeper.NewGovPermissionKeeper(m.wasmKeeper)
 }
 
 func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) error {
-	if wasmPermMode == "permissionless" {
-		return nil
-	}
 	err := m.checkActor(ctx, actor)
 	if err != nil {
 		return err
@@ -374,9 +366,6 @@ func (m WasmMgrVCUR) checkCanStore(ctx cosmos.Context, actor cosmos.AccAddress) 
 }
 
 func (m WasmMgrVCUR) checkCanInstantiate(ctx cosmos.Context, actor cosmos.AccAddress) error {
-	if wasmPermMode == "permissionless" {
-		return nil
-	}
 	err := m.checkActor(ctx, actor)
 	if err != nil {
 		return err

--- a/x/thorchain/managers.go
+++ b/x/thorchain/managers.go
@@ -593,7 +593,7 @@ func GetSecuredAssetManager(version semver.Version, keeper keeper.Keeper, eventM
 
 func GetWasmManager(ctx cosmos.Context, keeper keeper.Keeper, wasmKeeper wasmkeeper.Keeper, eventMgr EventManager) (WasmManager, error) {
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("THOR_WASM_MANAGER")), "bloctopus") {
-		return bloctopus.NewWasmMgrPermissionless(keeper, wasmKeeper, eventMgr)
+		return bloctopus.NewWasmMgrPermissionless(keeper, wasmKeeper)
 	}
 	return newWasmMgrVCUR(keeper, wasmKeeper, wasmpermissions.GetWasmPermissions(), eventMgr)
 }

--- a/x/thorchain/managers.go
+++ b/x/thorchain/managers.go
@@ -3,6 +3,9 @@ package thorchain
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+
 
 	"cosmossdk.io/core/store"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
@@ -21,6 +24,8 @@ import (
 	"gitlab.com/thorchain/thornode/v3/x/thorchain/keeper"
 	kv1 "gitlab.com/thorchain/thornode/v3/x/thorchain/keeper/v1"
 	"gitlab.com/thorchain/thornode/v3/x/thorchain/types"
+	"gitlab.com/thorchain/thornode/v3/x/bloctopus"
+
 )
 
 const (
@@ -587,6 +592,9 @@ func GetSecuredAssetManager(version semver.Version, keeper keeper.Keeper, eventM
 }
 
 func GetWasmManager(ctx cosmos.Context, keeper keeper.Keeper, wasmKeeper wasmkeeper.Keeper, eventMgr EventManager) (WasmManager, error) {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("THOR_WASM_MANAGER")), "bloctopus") {
+		return bloctopus.NewWasmMgrPermissionless(keeper, wasmKeeper, eventMgr)
+	}
 	return newWasmMgrVCUR(keeper, wasmKeeper, wasmpermissions.GetWasmPermissions(), eventMgr)
 }
 


### PR DESCRIPTION
# Add bloctopus permissionless WASM manager with runtime env selection

## Summary
Introduces a new permissionless WASM manager under `x/bloctopus` that bypasses all governance and permission checks for WASM operations (store, instantiate, execute, migrate, admin). The manager is selected at runtime via `THOR_WASM_MANAGER=bloctopus` environment variable, with the existing governance-controlled manager remaining as the default.

**Key changes:**
- New `x/bloctopus/wasm_manager.go`: Complete WasmManager implementation using `wasmkeeper.NewDefaultPermissionKeeper` (no restrictions)
- Modified `x/thorchain/managers.go`: Runtime env-based manager selection in `GetWasmManager()`
- **Default behavior unchanged**: Existing governance controls remain active unless env var explicitly set

## Review & Testing Checklist for Human
**⚠️ HIGH RISK - Security-sensitive changes**

- [ ] **Security review**: Verify permissionless manager is only intended for development/testing environments, never production
- [ ] **Interface compliance**: Confirm `WasmMgrPermissionless` correctly implements all `WasmManager` interface methods with expected signatures and error handling
- [ ] **Runtime switching**: Test that `THOR_WASM_MANAGER=bloctopus` properly switches managers and that any other value (or unset) uses default governance-controlled manager  
- [ ] **End-to-end testing**: Deploy contracts using both managers to verify permissionless path works and default path still enforces governance
- [ ] **Production safeguards**: Ensure deployment configurations/documentation clearly indicate when this env var should/shouldn't be used

### Notes
- This enables development workflows that don't require MIMIR governance transactions or hardcoded address allowlists
- The permissionless manager uses cosmwasm's default permission keeper which allows all operations
- Tested successfully with rujira-bow contract deployment, instantiation, funding, and execution
- Session requested by @tiljrd - [Devin run](https://app.devin.ai/sessions/54ee3a8133e14e89bf32a2d936530af4)