### PR TITLE
fix(diff-writer): align ABCI plugin imports and remove invalid ResponseCommit.Data usage

### DIFF
--- a/cmd/diff-writer/main.go
+++ b/cmd/diff-writer/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,11 +35,10 @@ type kvWrite struct {
 }
 
 type diffFile struct {
-	BaseHeight   int64     `json:"base_height"`
-	Height       int64     `json:"height"`
-	Time         string    `json:"time"`
-	AppHashAfter string    `json:"app_hash_after,omitempty"`
-	StoreWrites  []kvWrite `json:"store_writes"`
+	BaseHeight  int64     `json:"base_height"`
+	Height      int64     `json:"height"`
+	Time        string    `json:"time"`
+	StoreWrites []kvWrite `json:"store_writes"`
 }
 
 func (p *filePlugin) ListenFinalizeBlock(ctx context.Context, req abcitypes.RequestFinalizeBlock, res abcitypes.ResponseFinalizeBlock) error {
@@ -53,11 +51,10 @@ func (p *filePlugin) ListenCommit(ctx context.Context, res abcitypes.ResponseCom
 		height = time.Now().UnixNano()
 	}
 	df := diffFile{
-		BaseHeight:   p.baseHeight,
-		Height:       height,
-		Time:         time.Now().UTC().Format(time.RFC3339Nano),
-		AppHashAfter: fmt.Sprintf("%X", res.Data),
-		StoreWrites:  make([]kvWrite, 0, len(changeSet)),
+		BaseHeight:  p.baseHeight,
+		Height:      height,
+		Time:        time.Now().UTC().Format(time.RFC3339Nano),
+		StoreWrites: make([]kvWrite, 0, len(changeSet)),
 	}
 	for _, ch := range changeSet {
 		op := "set"


### PR DESCRIPTION
### **User description**
# fix(diff-writer): align ABCI plugin imports and remove invalid ResponseCommit.Data usage

## Summary
Fixes IDE compilation errors in the newly added ABCI diff-writer plugin by removing usage of `ResponseCommit.Data` field which doesn't exist in CometBFT's `ResponseCommit` type. Also removes the corresponding `AppHashAfter` field from the diff JSON output and cleans up the unused `fmt` import.

This addresses the "Unresolved reference 'Data'" IDE warnings reported after merging the initial plugin implementation in #16.

**Changes:**
- Remove `res.Data` usage in `ListenCommit` method (this field doesn't exist on `ResponseCommit`)
- Remove `AppHashAfter` field from `diffFile` struct and JSON output
- Remove unused `fmt` import
- Keep existing functionality for capturing per-block KV store changes

## Review & Testing Checklist for Human
- [ ] **Verify compilation**: Confirm `go build ./cmd/diff-writer` succeeds without errors
- [ ] **Test Docker build**: Run `docker build -t test -f build/docker/Dockerfile .` to ensure packaging works
- [ ] **End-to-end smoke test**: Run the plugin with a test thornode instance and verify diff files are still generated in the expected JSON format (without `app_hash_after` field)

### Notes
- The removed `AppHashAfter` field was attempting to capture app hash information, but this data should be obtained from a different source if needed in the future
- Core diff functionality (capturing store writes per block) remains unchanged
- This is a follow-up fix to the initial ABCI streaming plugin added in #16

Link to Devin run: https://app.devin.ai/sessions/e72fee05e6bf470182b09dc6ffce468d  
Requester: Til Jordan (@tiljrd)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove invalid `ResponseCommit.Data` field usage

- Clean up unused `fmt` import

- Remove `AppHashAfter` from JSON output structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ResponseCommit.Data"] -- "remove invalid field" --> B["Fixed compilation"]
  C["fmt import"] -- "remove unused" --> B
  D["AppHashAfter field"] -- "remove from struct" --> E["Simplified JSON output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Fix compilation errors and clean up code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-writer/main.go

<ul><li>Remove unused <code>fmt</code> import from imports section<br> <li> Remove <code>AppHashAfter</code> field from <code>diffFile</code> struct<br> <li> Remove invalid <code>res.Data</code> usage in <code>ListenCommit</code> method<br> <li> Simplify struct initialization without removed fields</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/17/files#diff-898bd9f3eda34c9f5833e3e762f2db843a0b2cba5dea0f857a45c206cee5ec41">+8/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

