### PR TITLE
feat(diff-api): API server for cumulative KV diffs with checkpoints, sharding, and gzip

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -19,6 +19,7 @@ ARG COMMIT=unknown
 
 RUN make install
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/diff-writer ./cmd/diff-writer || true
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/diff-api ./cmd/diff-api || true
 
 ########################################################################################
 # Deploy
@@ -44,6 +45,7 @@ RUN apt-get update && \
 COPY --from=build /go/bin/thornode /go/bin/bifrost /go/bin/recover-keyshare-backup /usr/bin/
 COPY --from=build /go/pkg/mod/github.com/!cosm!wasm/wasmvm/v2@v2.1.2/internal/api/libwasmvm.*.so /usr/lib
 COPY --from=build /go/bin/diff-writer /usr/local/bin/diff-writer
+COPY --from=build /go/bin/diff-api /usr/local/bin/diff-api
 
 COPY build/scripts /scripts
 

--- a/cmd/diff-api/main.go
+++ b/cmd/diff-api/main.go
@@ -1,0 +1,467 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type kvWrite struct {
+	Store string `json:"store"`
+	Op    string `json:"op"`
+	Key   string `json:"key_hex"`
+	Value string `json:"value_b64,omitempty"`
+}
+
+type blockDiff struct {
+	BaseHeight  int64     `json:"base_height"`
+	Height      int64     `json:"height"`
+	Time        string    `json:"time"`
+	StoreWrites []kvWrite `json:"store_writes"`
+}
+
+type cumulativeResponse struct {
+	BaseHeight   int64     `json:"base_height"`
+	TargetHeight int64     `json:"target_height"`
+	StoreWrites  []kvWrite `json:"store_writes"`
+}
+
+func envStr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if x, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return x
+		}
+	}
+	return def
+}
+
+func parseHeightParam(s string) (int64, error) {
+	h, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil || h <= 0 {
+		return 0, fmt.Errorf("invalid height: %q", s)
+	}
+	return h, nil
+}
+
+func shardPrefix(height int64, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	s := strconv.FormatInt(height, 10)
+	if len(s) <= width {
+		return s
+	}
+	return s[:width]
+}
+
+func openMaybeGzip(path string) (io.ReadCloser, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(path, ".gz") {
+		gz, gzErr := gzip.NewReader(f)
+		if gzErr != nil {
+			f.Close()
+			return nil, gzErr
+		}
+		return struct {
+			io.Reader
+			io.Closer
+		}{Reader: gz, Closer: f}, nil
+	}
+	return f, nil
+}
+
+func heightPaths(dir string, height int64, shardWidth int) []string {
+	base := filepath.Join(dir, fmt.Sprintf("%d.json", height))
+	gz := base + ".gz"
+	if shardWidth > 0 {
+		prefix := shardPrefix(height, shardWidth)
+		baseSh := filepath.Join(dir, prefix, fmt.Sprintf("%d.json", height))
+		return []string{baseSh, baseSh + ".gz", base, gz}
+	}
+	return []string{base, gz}
+}
+
+func readBlockDiff(dir string, height int64) (*blockDiff, error) {
+	for _, p := range heightPaths(dir, height, envInt("SHARD_WIDTH", 0)) {
+		rc, err := openMaybeGzip(p)
+		if err != nil {
+			continue
+		}
+		defer rc.Close()
+		dec := json.NewDecoder(rc)
+		var bd blockDiff
+		if err := dec.Decode(&bd); err != nil {
+			return nil, err
+		}
+		return &bd, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func listAvailableHeights(dir string) ([]int64, error) {
+	shardW := envInt("SHARD_WIDTH", 0)
+	var ents []os.DirEntry
+	var err error
+	if shardW <= 0 {
+		ents, err = os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		top, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range top {
+			if !e.IsDir() {
+				continue
+			}
+			sub, err := os.ReadDir(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			ents = append(ents, sub...)
+		}
+	}
+	out := make([]int64, 0, len(ents))
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		n := strings.TrimSuffix(name, ".json")
+		if strings.HasSuffix(n, ".gz") {
+			continue
+		}
+		if h, err := strconv.ParseInt(n, 10, 64); err == nil && h > 0 {
+			out = append(out, h)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+func writeJSON(w http.ResponseWriter, r *http.Request, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enableGzip := envInt("ENABLE_GZIP", 1) == 1
+	if enableGzip && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		enc := json.NewEncoder(gz)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(v)
+		return
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func foldCumulativeFromTo(dir string, start, target int64, last map[string]kvWrite) error {
+	for h := start; h <= target; h++ {
+		bd, err := readBlockDiff(dir, h)
+		if err != nil {
+			continue
+		}
+		for _, w := range bd.StoreWrites {
+			k := w.Store + "\x00" + w.Key
+			last[k] = w
+		}
+	}
+	return nil
+}
+
+func sortPatch(m map[string]kvWrite) []kvWrite {
+	ws := make([]kvWrite, 0, len(m))
+	for _, w := range m {
+		ws = append(ws, w)
+	}
+	sort.Slice(ws, func(i, j int) bool {
+		if ws[i].Store != ws[j].Store {
+			return ws[i].Store < ws[j].Store
+		}
+		return ws[i].Key < ws[j].Key
+	})
+	return ws
+}
+
+func loadCheckpoint(dir string, h int64) (map[string]kvWrite, bool) {
+	path := filepath.Join(dir, fmt.Sprintf("%d.json", h))
+	rc, err := openMaybeGzip(path)
+	if err != nil {
+		return nil, false
+	}
+	defer rc.Close()
+	var resp cumulativeResponse
+	if err := json.NewDecoder(rc).Decode(&resp); err != nil {
+		return nil, false
+	}
+	m := make(map[string]kvWrite, len(resp.StoreWrites))
+	for _, w := range resp.StoreWrites {
+		m[w.Store+"\x00"+w.Key] = w
+	}
+	return m, true
+}
+
+func floorCheckpoint(checkDir string, base, target int64, interval int) int64 {
+	if interval <= 0 {
+		return 0
+	}
+	c := (target / int64(interval)) * int64(interval)
+	if c <= base {
+		return 0
+	}
+	if _, ok := loadCheckpoint(checkDir, c); ok {
+		return c
+	}
+	return 0
+}
+
+func foldCumulative(dir string, base, target int64) (cumulativeResponse, error) {
+	if target <= base {
+		return cumulativeResponse{}, errors.New("target must be > base")
+	}
+	last := make(map[string]kvWrite)
+	checkDir := envStr("CHECKPOINT_DIR", filepath.Join(dir, "checkpoints"))
+	interval := envInt("CHECKPOINT_INTERVAL", 1000)
+
+	if c := floorCheckpoint(checkDir, base, target, interval); c > 0 {
+		if m, ok := loadCheckpoint(checkDir, c); ok {
+			for k, v := range m {
+				last[k] = v
+			}
+			_ = foldCumulativeFromTo(dir, c+1, target, last)
+		} else {
+			_ = foldCumulativeFromTo(dir, base+1, target, last)
+		}
+	} else {
+		_ = foldCumulativeFromTo(dir, base+1, target, last)
+	}
+
+	return cumulativeResponse{
+		BaseHeight:   base,
+		TargetHeight: target,
+		StoreWrites:  sortPatch(last),
+	}, nil
+}
+
+func handleDiffSince(outDir string, base int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) != 3 {
+			http.Error(w, "use /diffs/since/{height}", http.StatusBadRequest)
+			return
+		}
+		h, err := parseHeightParam(parts[2])
+			if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := foldCumulative(outDir, base, h)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, r, resp)
+	}
+}
+
+func handleDiffHeight(outDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) != 3 {
+			http.Error(w, "use /diffs/height/{height}", http.StatusBadRequest)
+			return
+		}
+		h, err := parseHeightParam(parts[2])
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var rc io.ReadCloser
+		var opened bool
+		for _, p := range heightPaths(outDir, h, envInt("SHARD_WIDTH", 0)) {
+			rcc, err := openMaybeGzip(p)
+			if err != nil {
+				continue
+			}
+			rc = rcc
+			opened = true
+			break
+		}
+		if !opened {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		defer func() {
+			if rc != nil {
+				rc.Close()
+			}
+		}()
+		w.Header().Set("Content-Type", "application/json")
+		io.Copy(w, rc)
+	}
+}
+
+func handleMeta(outDir string, base int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		hs, err := listAvailableHeights(outDir)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		type meta struct {
+			BaseHeight int64   `json:"base_height"`
+			Min        int64   `json:"min_height"`
+			Max        int64   `json:"max_height"`
+			Count      int     `json:"count"`
+			Sample     []int64 `json:"sample"`
+		}
+		m := meta{BaseHeight: base, Count: len(hs)}
+		if len(hs) > 0 {
+			m.Min = hs[0]
+			m.Max = hs[len(hs)-1]
+			if len(hs) > 10 {
+				m.Sample = append(m.Sample, hs[:5]...)
+				m.Sample = append(m.Sample, hs[len(hs)-5:]...)
+			} else {
+				m.Sample = hs
+			}
+		}
+		writeJSON(w, r, m)
+	}
+}
+
+func handleValidatePatch() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ws []kvWrite
+		if err := json.NewDecoder(r.Body).Decode(&ws); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		type res struct {
+			Count int    `json:"count"`
+			OK    bool   `json:"ok"`
+			Err   string `json:"err,omitempty"`
+		}
+		for _, wv := range ws {
+			if _, err := hex.DecodeString(wv.Key); err != nil {
+				writeJSON(w, r, res{OK: false, Err: "bad key_hex"})
+				return
+			}
+			if wv.Op != "set" && wv.Op != "delete" {
+				writeJSON(w, r, res{OK: false, Err: "bad op"})
+				return
+			}
+			if wv.Op == "set" && wv.Value != "" {
+				if _, err := base64.StdEncoding.DecodeString(wv.Value); err != nil {
+					writeJSON(w, r, res{OK: false, Err: "bad value_b64"})
+					return
+				}
+			}
+		}
+		writeJSON(w, r, res{OK: true, Count: len(ws)})
+	}
+}
+
+func buildCheckpoints(outDir string, base int64) {
+	interval := envInt("CHECKPOINT_INTERVAL", 1000)
+	if interval <= 0 {
+		return
+	}
+	checkDir := envStr("CHECKPOINT_DIR", filepath.Join(outDir, "checkpoints"))
+	_ = os.MkdirAll(checkDir, 0o755)
+	hs, err := listAvailableHeights(outDir)
+	if err != nil || len(hs) == 0 {
+		return
+	}
+	last := make(map[string]kvWrite)
+	start := base + 1
+	for _, h := range hs {
+		if h < start {
+			continue
+		}
+		bd, err := readBlockDiff(outDir, h)
+		if err != nil {
+			continue
+		}
+		for _, w := range bd.StoreWrites {
+			last[w.Store+"\x00"+w.Key] = w
+		}
+		if h%int64(interval) == 0 {
+			cp := cumulativeResponse{
+				BaseHeight:   base,
+				TargetHeight: h,
+				StoreWrites:  sortPatch(last),
+			}
+			tmp := filepath.Join(checkDir, fmt.Sprintf("%d.json.tmp", h))
+			out := filepath.Join(checkDir, fmt.Sprintf("%d.json", h))
+			f, err := os.Create(tmp)
+			if err != nil {
+				continue
+			}
+			enc := json.NewEncoder(f)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(cp)
+			_ = f.Close()
+			_ = os.Rename(tmp, out)
+		}
+	}
+}
+
+func main() {
+	outDir := envStr("THOR_DIFF_OUT", "/root/.thornode/diffs")
+	baseStr := envStr("THOR_DIFF_BASE_HEIGHT", "")
+	var base int64
+	if baseStr != "" {
+		if v, err := strconv.ParseInt(baseStr, 10, 64); err == nil {
+			base = v
+		}
+	}
+	if base == 0 {
+		if hs, err := listAvailableHeights(outDir); err == nil && len(hs) > 0 {
+			if bd, err := readBlockDiff(outDir, hs[0]); err == nil {
+				base = bd.BaseHeight
+			}
+		}
+	}
+
+	go buildCheckpoints(outDir, base)
+
+	mux := http.NewServeMux()
+	mux.Handle("/diffs/since/", handleDiffSince(outDir, base))
+	mux.Handle("/diffs/height/", handleDiffHeight(outDir))
+	mux.Handle("/diffs/block/", handleDiffHeight(outDir))
+	mux.Handle("/diffs/meta", handleMeta(outDir, base))
+	mux.Handle("/diffs/validate", handleValidatePatch())
+
+	addr := envStr("DIFF_API_ADDR", ":8080")
+	fmt.Printf("diff-api listening on %s, out=%s, base=%d\n", addr, outDir, base)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		panic(err)
+	}
+}

--- a/docs/abci-diff-streaming.md
+++ b/docs/abci-diff-streaming.md
@@ -43,6 +43,13 @@ Output format
   ]
 }
 
+Consume diffs via API
+- A minimal diff-API server is provided as a separate binary under cmd/diff-api.
+- See docs/diff-api.md for build/run and endpoints to request:
+  - Per-block diffs: GET /diffs/height/{H}
+  - Cumulative diffs since base: GET /diffs/since/{H}
+- Enable gzip and checkpoints for efficient queries and smaller payloads.
+
 Verification
 - curl http://localhost:27147/status
 - curl http://localhost:1317/cosmos/bank/v1beta1/balances/{address}

--- a/docs/diff-api.md
+++ b/docs/diff-api.md
@@ -1,0 +1,49 @@
+diff-api server
+
+Build
+- go build ./cmd/diff-api
+
+Runtime env
+- THOR_DIFF_OUT: directory containing per-block diff JSONs (from diff-writer), default /root/.thornode/diffs
+- THOR_DIFF_BASE_HEIGHT: base height (optional; inferred from files if unset)
+- DIFF_API_ADDR: listen address (default :8080)
+- CHECKPOINT_INTERVAL: build cumulative checkpoints every N blocks (default 1000; set 0 to disable)
+- CHECKPOINT_DIR: directory for checkpoints (default $THOR_DIFF_OUT/checkpoints)
+- SHARD_WIDTH: read sharded per-block diffs at $THOR_DIFF_OUT/{prefix}/{height}.json, where prefix=first SHARD_WIDTH digits (default 0=disabled)
+- ENABLE_GZIP: if 1 (default), compress JSON responses when client sends Accept-Encoding: gzip
+
+Endpoints
+- GET /diffs/meta → { base_height, min_height, max_height, count, sample }
+- GET /diffs/height/{H} and GET /diffs/block/{H} → return the per-block diff file for height H (supports .json and .json.gz; sharded or flat)
+- GET /diffs/since/{H} → returns cumulative KV patch from (base_height, H], using last-write-wins per (store,key). If checkpoints exist, serves “nearest checkpoint + tail” for near O(1).
+- POST /diffs/validate → validate a list of kvWrite items (decode checks)
+
+Behavior
+- Deterministic output: cumulative patches are stably sorted by store then key.
+- Checkpoints: on startup, the server scans available heights and writes checkpoints every CHECKPOINT_INTERVAL blocks to $CHECKPOINT_DIR. Existing checkpoints are reused automatically by /diffs/since/{H}.
+- Sharding: server transparently reads flat and sharded layouts; you can enable sharding when generating diffs in the future without breaking compatibility.
+- Gzip: responses are compressed when the client requests it (and ENABLE_GZIP=1).
+
+Applying patches to base genesis efficiently
+- The KV patch represents final values per (store,key) after folding from (base, H]. For O(1)-ish apply over a large base file:
+  - Recommended: build a KV index representation of the base state once (keyed by (store,key)), then stream-apply the patch to that index and re-materialize JSON if required.
+  - Directly rewriting a 700MB monolithic JSON in place is slow and fragile. A KV index approach is faster and single-pass.
+- The patch entries:
+  - {store, op: "set"|"delete", key_hex, value_b64?}. For "delete", value_b64 is empty.
+
+Docker
+- The Dockerfile builds and includes /usr/local/bin/diff-api in the thornode image.
+- Example run:
+  docker run --rm -it -p 8080:8080 \
+    -v /thornode/diffs:/root/.thornode/diffs \
+    -e THOR_DIFF_OUT=/root/.thornode/diffs \
+    -e THOR_DIFF_BASE_HEIGHT=23010004 \
+    -e CHECKPOINT_INTERVAL=1000 \
+    -e ENABLE_GZIP=1 \
+    tiljordan/thornode-forking:local /usr/local/bin/diff-api
+
+Verification
+- curl localhost:8080/diffs/meta
+- curl localhost:8080/diffs/height/23011828
+- curl localhost:8080/diffs/since/23011828
+- ls /thornode/diffs/checkpoints | head  # after some time if checkpoints enabled


### PR DESCRIPTION
### **User description**
# feat(diff-api): API server for cumulative KV diffs with checkpoints, sharding, and gzip

## Summary
Adds a new `diff-api` HTTP server that reads per-block KV diff files (generated by the existing `diff-writer` plugin) and serves cumulative diffs for any target height. This enables querying "what changes are needed to transform base state at height X to target state at height Y" efficiently.

**Key features:**
- **Cumulative diff serving**: `/diffs/since/{H}` folds per-block changes using last-write-wins semantics per (store,key)
- **Performance optimizations**: Periodic checkpoints (default every 1000 blocks) for near O(1) serving of large ranges
- **File layout flexibility**: Transparently reads flat directories, sharded directories, and gzipped files
- **HTTP API**: Serves metadata, individual block diffs, cumulative diffs, and validation endpoints
- **Gzip compression**: Compresses responses when clients request it

The server is designed to handle large datasets (hundreds of thousands of diff files) and minimize network payload sizes for the use case of applying changes to a 700MB+ genesis file.

## Review & Testing Checklist for Human (5 items)

- [ ] **Verify folding logic correctness**: Test `/diffs/since/{H}` with known per-block diffs and manually verify that the cumulative patch correctly represents last-write-wins semantics across the range. This is the core business logic and most critical to get right.
- [ ] **Test with real diff-writer output**: Run `diff-api` pointing to an actual directory of files produced by `diff-writer` and verify endpoints return sensible data (not just that they don't crash).
- [ ] **Validate checkpoint behavior**: Enable checkpoints, let them build, then verify that `/diffs/since/{H}` returns identical results before and after checkpoint creation for the same height range.
- [ ] **Test file handling edge cases**: Verify behavior with missing files, corrupted JSON, mixed flat/sharded layouts, and gzipped vs plain files.
- [ ] **End-to-end functionality**: Confirm that the KV patches returned by `/diffs/since/{H}` contain the data needed for the intended use case of applying changes to a base genesis file.

### Notes
- The server includes comprehensive documentation and Docker integration
- Checkpoint building runs asynchronously on startup - may need time to complete for large datasets  
- Client-side application of KV patches is recommended via building an index rather than directly modifying large JSON files
- All major configuration is controlled via environment variables with sensible defaults

**Link to Devin run:** https://app.devin.ai/sessions/e72fee05e6bf470182b09dc6ffce468d  
**Requested by:** @tiljrd


___

### **PR Type**
Enhancement


___

### **Description**
- Add HTTP API server for cumulative KV diffs

- Support checkpoints for O(1) serving performance

- Enable gzip compression and sharded file layouts

- Include Docker integration and comprehensive documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["diff-writer files"] --> B["diff-api server"]
  B --> C["HTTP endpoints"]
  C --> D["/diffs/since/{H}"]
  C --> E["/diffs/height/{H}"]
  C --> F["/diffs/meta"]
  B --> G["checkpoint builder"]
  G --> H["periodic checkpoints"]
  H --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Complete diff-api HTTP server implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/main.go

<ul><li>Implement HTTP server with 5 endpoints for diff serving<br> <li> Add cumulative diff folding with last-write-wins semantics<br> <li> Support checkpoint-based optimization for large ranges<br> <li> Handle sharded/flat file layouts and gzip compression</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/20/files#diff-34d06e19fe2456a0f45f6e86105e7ef10b7da0b948f5775f775326a3c1d56edd">+467/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add diff-api binary to Docker build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/docker/Dockerfile

<ul><li>Build diff-api binary in Docker image<br> <li> Copy diff-api to /usr/local/bin/ in final image</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/20/files#diff-2e245700d3161b3c801e7beced5e460a3f240958ef7d55d21d1740cea569ec52">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>abci-diff-streaming.md</strong><dd><code>Link to diff-api consumption guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/abci-diff-streaming.md

<ul><li>Add section linking to diff-api server<br> <li> Document API endpoints for consuming diffs</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/20/files#diff-e61fabd0ee03bd6f604950bb53423d7dd293ce4769af9bd87767f9349405c209">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diff-api.md</strong><dd><code>Comprehensive diff-api server documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/diff-api.md

<ul><li>Complete documentation for diff-api server<br> <li> Cover build, runtime configuration, endpoints<br> <li> Include Docker usage and verification examples</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/20/files#diff-0fe1da840561c532670c7904d6ab6922f1758f9b83f9d321a689c14f99965ec7">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

