### PR TITLE
diff-api(aggregator): include auth.accounts from acc store in high-level patch

### DIFF
--- a/cmd/diff-api/aggregator/acc.go
+++ b/cmd/diff-api/aggregator/acc.go
@@ -1,0 +1,149 @@
+package aggregator
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+func aggregateAcc(ws []KVWrite) (map[string]any, bool) {
+	const storeKey = authtypes.StoreKey
+
+	accMap := make(map[string]map[string]any)
+	changed := false
+
+	for _, w := range ws {
+		if w.Store != storeKey {
+			continue
+		}
+		if w.Op == "delete" || w.Value == "" {
+			continue
+		}
+		bz, err := base64.StdEncoding.DecodeString(w.Value)
+		if err != nil {
+			continue
+		}
+
+		var addr string
+		var m map[string]any
+
+		if ba := new(authtypes.BaseAccount); appCodec.Unmarshal(bz, ba) == nil && ba.Address != "" {
+			if jb, err := appCodec.MarshalJSON(ba); err == nil {
+				var mm map[string]any
+				if json.Unmarshal(jb, &mm) == nil {
+					m = mm
+					addr = strings.TrimSpace(ba.Address)
+				}
+			}
+		} else {
+			switch {
+			case func() bool {
+				cv := new(vestingtypes.ContinuousVestingAccount)
+				if appCodec.Unmarshal(bz, cv) != nil {
+					return false
+				}
+				jb, err := appCodec.MarshalJSON(cv)
+				if err != nil {
+					return false
+				}
+				var mm map[string]any
+				if json.Unmarshal(jb, &mm) != nil {
+					return false
+				}
+				if bva, ok := mm["base_vesting_account"].(map[string]any); ok {
+					if ba, ok := bva["base_account"].(map[string]any); ok {
+						if a, ok := ba["address"].(string); ok {
+							addr = strings.TrimSpace(a)
+							m = mm
+							return addr != ""
+						}
+					}
+				}
+				return false
+			}():
+			case func() bool {
+				dv := new(vestingtypes.DelayedVestingAccount)
+				if appCodec.Unmarshal(bz, dv) != nil {
+					return false
+				}
+				jb, err := appCodec.MarshalJSON(dv)
+				if err != nil {
+					return false
+				}
+				var mm map[string]any
+				if json.Unmarshal(jb, &mm) != nil {
+					return false
+				}
+				if bva, ok := mm["base_vesting_account"].(map[string]any); ok {
+					if ba, ok := bva["base_account"].(map[string]any); ok {
+						if a, ok := ba["address"].(string); ok {
+							addr = strings.TrimSpace(a)
+							m = mm
+							return addr != ""
+						}
+					}
+				}
+				return false
+			}():
+			case func() bool {
+				pv := new(vestingtypes.PeriodicVestingAccount)
+				if appCodec.Unmarshal(bz, pv) != nil {
+					return false
+				}
+				jb, err := appCodec.MarshalJSON(pv)
+				if err != nil {
+					return false
+				}
+				var mm map[string]any
+				if json.Unmarshal(jb, &mm) != nil {
+					return false
+				}
+				if bva, ok := mm["base_vesting_account"].(map[string]any); ok {
+					if ba, ok := bva["base_account"].(map[string]any); ok {
+						if a, ok := ba["address"].(string); ok {
+							addr = strings.TrimSpace(a)
+							m = mm
+							return addr != ""
+						}
+					}
+				}
+				return false
+			}():
+			default:
+				// Fallback: try generic JSON unmarshal path if structure resembles BaseAccount
+				var ba authtypes.BaseAccount
+				if appCodec.Unmarshal(bz, &ba) == nil && ba.Address != "" {
+					if jb, err := appCodec.MarshalJSON(&ba); err == nil {
+						var mm map[string]any
+						if json.Unmarshal(jb, &mm) == nil {
+							m = mm
+							addr = strings.TrimSpace(ba.Address)
+						}
+					}
+				}
+			}
+		}
+
+		if addr == "" || m == nil {
+			continue
+		}
+		accMap[addr] = m
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	accounts := make([]map[string]any, 0, len(accMap))
+	for _, v := range accMap {
+		accounts = append(accounts, v)
+	}
+	out := map[string]any{
+		"accounts": accounts,
+	}
+	return out, true
+}

--- a/cmd/diff-api/aggregator/aggregator.go
+++ b/cmd/diff-api/aggregator/aggregator.go
@@ -23,6 +23,18 @@ func init() {
 
 func AggregateAppState(ws []KVWrite) (AppState, error) {
 	out := make(AppState)
+
+	if acc, ok := aggregateAcc(ws); ok && len(acc) > 0 {
+		auth, _ := out["auth"].(map[string]any)
+		if auth == nil {
+			auth = make(map[string]any)
+			out["auth"] = auth
+		}
+		if accs, ok := acc["accounts"]; ok {
+			auth["accounts"] = accs
+		}
+	}
+
 	if bank, ok := aggregateBank(ws); ok && len(bank) > 0 {
 		out["bank"] = bank
 	}


### PR DESCRIPTION
### **User description**
# diff-api(aggregator): include auth.accounts from acc store in high-level patch

## Summary
Extends the diff-api aggregator to include Cosmos auth accounts from the `acc` store in the high-level patch response. The new functionality:

- Adds `aggregateAcc()` function that processes acc store KV writes
- Decodes BaseAccount and common vesting account types (Continuous, Delayed, Periodic) 
- Deduplicates accounts by address (last write wins)
- Populates `app_state.auth.accounts` in the patch response
- Skips delete operations to simplify genesis patching

## Review & Testing Checklist for Human
This is a medium-risk change that adds new account decoding logic without comprehensive testing.

- [ ] **Test with real acc store data**: Verify the aggregator correctly decodes accounts from actual blockchain diff data at various heights
- [ ] **Validate account type coverage**: Confirm that BaseAccount + 3 vesting types cover all account types present in THORChain, or identify missing types
- [ ] **Check address extraction logic**: The complex fallback logic for extracting addresses from nested account structures needs validation with real data
- [ ] **Verify deduplication behavior**: Confirm that last-write-wins by address is the intended behavior for cumulative patches

### Test Plan
1. Run diff-api locally against existing diff data
2. Query `/bloctopus/diffs/patch/since/{height}` for a height with acc store writes  
3. Verify `app_state.auth.accounts` appears and contains properly formatted account objects
4. Spot-check that account addresses and types look correct

### Notes
- The anonymous function switch pattern is unusual but functional
- Delete operations are intentionally skipped to avoid removing base genesis accounts
- This change is part of implementing dynamic forking functionality for the THORChain Kurtosis package

**Link to Devin run**: https://app.devin.ai/sessions/9b406c834a9f43609789ae555874b8be  
**Requested by**: Til Jordan (@tiljrd)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Cosmos auth accounts aggregation to diff-api

- Support BaseAccount and vesting account types decoding

- Implement address-based deduplication with last-write-wins

- Skip delete operations for genesis patching compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  kvwrites["KV Writes"] --> accagg["aggregateAcc()"]
  accagg --> decode["Decode Account Types"]
  decode --> baseacc["BaseAccount"]
  decode --> vesting["Vesting Accounts"]
  vesting --> continuous["ContinuousVesting"]
  vesting --> delayed["DelayedVesting"] 
  vesting --> periodic["PeriodicVesting"]
  baseacc --> dedupe["Deduplicate by Address"]
  continuous --> dedupe
  delayed --> dedupe
  periodic --> dedupe
  dedupe --> appstate["app_state.auth.accounts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>acc.go</strong><dd><code>Add Cosmos auth accounts aggregation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/acc.go

<ul><li>New <code>aggregateAcc()</code> function to process acc store KV writes<br> <li> Decode BaseAccount and three vesting account types (Continuous, <br>Delayed, Periodic)<br> <li> Extract addresses from nested account structures with fallback logic<br> <li> Deduplicate accounts by address using map-based storage</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/24/files#diff-a77e3231fca4f33e149189f66b3eae0f29d1090d281e6d59096c7d9a9f566613">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aggregator.go</strong><dd><code>Integrate accounts aggregation into main aggregator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/aggregator.go

<ul><li>Integrate <code>aggregateAcc()</code> into main <code>AggregateAppState()</code> function<br> <li> Create auth section in output if accounts are found<br> <li> Populate <code>app_state.auth.accounts</code> with aggregated account data</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/24/files#diff-42472900e0d9995116dea94f2d88066f1842cce00057eefcd68874ed3b96bda9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

