### PR TITLE
Devin/1759589544 diff api appstate

### DIFF
--- a/cmd/diff-api/aggregator/acc.go
+++ b/cmd/diff-api/aggregator/acc.go
@@ -15,7 +15,6 @@ func aggregateAcc(ws []KVWrite) (map[string]any, bool) {
 	const storeKey = authtypes.StoreKey
 
 	accMap := make(map[string]map[string]any)
-	rawState := make([]map[string]string, 0)
 	changed := false
 
 	for _, w := range ws {
@@ -24,8 +23,6 @@ func aggregateAcc(ws []KVWrite) (map[string]any, bool) {
 		}
 		bz, err := base64.StdEncoding.DecodeString(w.Value)
 		if err != nil {
-			rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-			changed = true
 			continue
 		}
 
@@ -132,28 +129,20 @@ func aggregateAcc(ws []KVWrite) (map[string]any, bool) {
 			}
 		}
 		if ai == nil {
-			rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-			changed = true
 			continue
 		}
 
 		jb, err := appCodec.MarshalJSON(ai)
 		if err != nil {
-			rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-			changed = true
 			continue
 		}
 		var mm map[string]any
 		if json.Unmarshal(jb, &mm) != nil {
-			rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-			changed = true
 			continue
 		}
 		addr, _ := mm["address"].(string)
 		addr = strings.TrimSpace(addr)
 		if addr == "" {
-			rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-			changed = true
 			continue
 		}
 		accMap[addr] = mm
@@ -169,8 +158,5 @@ func aggregateAcc(ws []KVWrite) (map[string]any, bool) {
 		accounts = append(accounts, v)
 	}
 	out := map[string]any{"accounts": accounts}
-	if len(rawState) > 0 {
-		out["raw_state"] = rawState
-	}
 	return out, true
 }

--- a/cmd/diff-api/aggregator/aggregator.go
+++ b/cmd/diff-api/aggregator/aggregator.go
@@ -32,9 +32,6 @@ func AggregateAppState(ws []KVWrite) (AppState, error) {
 		if accs, ok := acc["accounts"]; ok {
 			auth["accounts"] = accs
 		}
-		if rs, ok := acc["raw_state"]; ok {
-			auth["raw_state"] = rs
-		}
 	}
 
 	if bank, ok := aggregateBank(ws); ok && len(bank) > 0 {

--- a/cmd/diff-api/aggregator/bank.go
+++ b/cmd/diff-api/aggregator/bank.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmath "cosmossdk.io/math"
@@ -13,6 +14,8 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 	const storeKey = banktypes.StoreKey
 
 	balancesByAddr := make(map[string]map[string]string)
+	metadatas := make([]map[string]any, 0)
+	var paramsOut map[string]any
 	changed := false
 
 	for _, w := range ws {
@@ -26,10 +29,10 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 		if err != nil || len(kb) == 0 {
 			continue
 		}
-	switch kb[0] {
-	case 0x00:
-		changed = true
-	case 0x02:
+		switch kb[0] {
+		case 0x00:
+			changed = true
+		case 0x02:
 			if len(kb) < 3 {
 				continue
 			}
@@ -56,7 +59,42 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 			}
 			balancesByAddr[addr][denom] = amt.String()
 			changed = true
-	default:
+
+		case 0x03:
+			vb, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil || len(vb) == 0 {
+				continue
+			}
+			var md banktypes.Metadata
+			if err := appCodec.Unmarshal(vb, &md); err != nil {
+				continue
+			}
+			if jb, err := appCodec.MarshalJSON(&md); err == nil {
+				var mm map[string]any
+				if err := json.Unmarshal(jb, &mm); err == nil && len(mm) > 0 {
+					metadatas = append(metadatas, mm)
+					changed = true
+				}
+			}
+
+		case 0x11:
+			vb, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil || len(vb) == 0 {
+				continue
+			}
+			var pm banktypes.Params
+			if err := appCodec.Unmarshal(vb, &pm); err != nil {
+				continue
+			}
+			if jb, err := appCodec.MarshalJSON(&pm); err == nil {
+				var mm map[string]any
+				if err := json.Unmarshal(jb, &mm); err == nil && len(mm) > 0 {
+					paramsOut = mm
+					changed = true
+				}
+			}
+
+		default:
 			continue
 		}
 	}
@@ -81,6 +119,12 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 			})
 		}
 		out["balances"] = bals
+	}
+	if len(metadatas) > 0 {
+		out["denom_metadata"] = metadatas
+	}
+	if len(paramsOut) > 0 {
+		out["params"] = paramsOut
 	}
 	if len(out) == 0 {
 		return nil, false

--- a/cmd/diff-api/aggregator/bank.go
+++ b/cmd/diff-api/aggregator/bank.go
@@ -13,7 +13,6 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 	const storeKey = banktypes.StoreKey
 
 	balancesByAddr := make(map[string]map[string]string)
-	rawState := make([]map[string]string, 0)
 	changed := false
 
 	for _, w := range ws {
@@ -58,11 +57,7 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 			balancesByAddr[addr][denom] = amt.String()
 			changed = true
 	default:
-			rawState = append(rawState, map[string]string{
-				"key_hex":   w.Key,
-				"value_b64": w.Value,
-			})
-			changed = true
+			continue
 		}
 	}
 
@@ -86,9 +81,6 @@ func aggregateBank(ws []KVWrite) (map[string]any, bool) {
 			})
 		}
 		out["balances"] = bals
-	}
-	if len(rawState) > 0 {
-		out["raw_state"] = rawState
 	}
 	if len(out) == 0 {
 		return nil, false

--- a/cmd/diff-api/aggregator/thorchain.go
+++ b/cmd/diff-api/aggregator/thorchain.go
@@ -12,7 +12,6 @@ import (
 func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 	var pools []map[string]any
 	var mimirs []map[string]any
-	var rawState []map[string]string
 	changed := false
 
 	for _, w := range ws {
@@ -21,10 +20,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 		}
 		kb, err := hex.DecodeString(w.Key)
 		if err != nil {
-			if w.Op != "delete" && w.Value != "" {
-				rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-				changed = true
-			}
 			continue
 		}
 		key := string(kb)
@@ -43,8 +38,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 			}
 			var pool thorchaintypes.Pool
 			if err := appCodec.Unmarshal(bz, &pool); err != nil {
-				rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-				changed = true
 				continue
 			}
 			b, err := appCodec.MarshalJSON(&pool)
@@ -74,8 +67,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 			}
 			var v thorchaintypes.ProtoInt64
 			if err := appCodec.Unmarshal(bz, &v); err != nil {
-				rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-				changed = true
 				continue
 			}
 			mimirs = append(mimirs, map[string]any{
@@ -84,10 +75,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 			})
 			changed = true
 		default:
-			if w.Op != "delete" && w.Value != "" {
-				rawState = append(rawState, map[string]string{"key_hex": w.Key, "value_b64": w.Value})
-				changed = true
-			}
 		}
 	}
 
@@ -100,9 +87,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 	}
 	if len(mimirs) > 0 {
 		out["mimirs"] = mimirs
-	}
-	if len(rawState) > 0 {
-		out["raw_state"] = rawState
 	}
 	if len(out) == 0 {
 		return nil, false

--- a/cmd/diff-api/aggregator/thorchain.go
+++ b/cmd/diff-api/aggregator/thorchain.go
@@ -12,6 +12,10 @@ import (
 func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 	var pools []map[string]any
 	var mimirs []map[string]any
+	var nodes []map[string]any
+	var vaults []map[string]any
+	var lps []map[string]any
+	var outboundFees []map[string]any
 	changed := false
 
 	for _, w := range ws {
@@ -25,8 +29,6 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 		key := string(kb)
 
 		switch {
-		case strings.HasPrefix(key, "node_account/"), strings.HasPrefix(key, "vault/"):
-			continue
 		case strings.HasPrefix(key, "pool/"):
 			if w.Op == "delete" || w.Value == "" {
 				changed = true
@@ -52,6 +54,7 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 				pools = append(pools, m)
 				changed = true
 			}
+
 		case strings.HasPrefix(key, "mimir/"):
 			if w.Op == "delete" || w.Value == "" {
 				changed = true
@@ -74,7 +77,102 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 				"value": v.GetValue(),
 			})
 			changed = true
+
+		case strings.HasPrefix(key, "node_account/"):
+			if w.Op == "delete" || w.Value == "" {
+				changed = true
+				continue
+			}
+			bz, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil {
+				continue
+			}
+			var na thorchaintypes.NodeAccount
+			if err := appCodec.Unmarshal(bz, &na); err != nil {
+				continue
+			}
+			b, err := appCodec.MarshalJSON(&na)
+			if err != nil {
+				continue
+			}
+			var m map[string]any
+			if json.Unmarshal(b, &m) == nil {
+				nodes = append(nodes, m)
+				changed = true
+			}
+
+		case strings.HasPrefix(key, "vault/"):
+			if w.Op == "delete" || w.Value == "" {
+				changed = true
+				continue
+			}
+			bz, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil {
+				continue
+			}
+			var v thorchaintypes.Vault
+			if err := appCodec.Unmarshal(bz, &v); err != nil {
+				continue
+			}
+			b, err := appCodec.MarshalJSON(&v)
+			if err != nil {
+				continue
+			}
+			var m map[string]any
+			if json.Unmarshal(b, &m) == nil {
+				vaults = append(vaults, m)
+				changed = true
+			}
+
+		case strings.HasPrefix(key, "liquidity_provider/"):
+			if w.Op == "delete" || w.Value == "" {
+				changed = true
+				continue
+			}
+			bz, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil {
+				continue
+			}
+			var lp thorchaintypes.LiquidityProvider
+			if err := appCodec.Unmarshal(bz, &lp); err != nil {
+				continue
+			}
+			b, err := appCodec.MarshalJSON(&lp)
+			if err != nil {
+				continue
+			}
+			var m map[string]any
+			if json.Unmarshal(b, &m) == nil {
+				lps = append(lps, m)
+				changed = true
+			}
+
+
+		case strings.HasPrefix(key, "outbound_fee/"):
+			if w.Op == "delete" || w.Value == "" {
+				changed = true
+				continue
+			}
+			denom := strings.TrimPrefix(key, "outbound_fee/")
+			if denom == "" {
+				continue
+			}
+			bz, err := base64.StdEncoding.DecodeString(w.Value)
+			if err != nil {
+				continue
+			}
+			var v thorchaintypes.ProtoInt64
+			if err := appCodec.Unmarshal(bz, &v); err != nil {
+				continue
+			}
+			outboundFees = append(outboundFees, map[string]any{
+				"denom": denom,
+				"value": v.GetValue(),
+			})
+			changed = true
+
 		default:
+			continue
 		}
 	}
 
@@ -87,6 +185,18 @@ func aggregateThorchain(ws []KVWrite) (map[string]any, bool) {
 	}
 	if len(mimirs) > 0 {
 		out["mimirs"] = mimirs
+	}
+	if len(nodes) > 0 {
+		out["nodes"] = nodes
+	}
+	if len(vaults) > 0 {
+		out["vaults"] = vaults
+	}
+	if len(lps) > 0 {
+		out["liquidity_providers"] = lps
+	}
+	if len(outboundFees) > 0 {
+		out["outbound_fees"] = outboundFees
 	}
 	if len(out) == 0 {
 		return nil, false

--- a/cmd/diff-api/aggregator/wasm.go
+++ b/cmd/diff-api/aggregator/wasm.go
@@ -2,10 +2,39 @@ package aggregator
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"unicode/utf8"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
+
+func tryUvarint(b []byte) (uint64, bool) {
+	var x uint64
+	var shift uint
+	for i := 0; i < len(b) && i < 10; i++ {
+		bt := b[i]
+		x |= uint64(bt&0x7F) << shift
+		if (bt & 0x80) == 0 {
+			return x, true
+		}
+		shift += 7
+	}
+	return 0, false
+}
+
+func isPrintableUTF8(b []byte) bool {
+	if !utf8.Valid(b) {
+		return false
+	}
+	for _, r := range string(b) {
+		if r == '\u0000' {
+			return false
+		}
+	}
+	return true
+}
 
 func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 	const storeKey = wasmtypes.StoreKey
@@ -13,6 +42,7 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 	codes := make([]map[string]any, 0)
 	contracts := make([]map[string]any, 0)
 	sequences := make(map[string]any)
+	contractStates := make(map[string][]map[string]any)
 
 	paramsOut := make(map[string]any)
 	changed := false
@@ -24,22 +54,15 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 		if w.Op == "delete" || w.Value == "" {
 			continue
 		}
+
 		if w.Key == "08" {
 			vb, err := base64.StdEncoding.DecodeString(w.Value)
 			if err == nil && len(vb) > 0 {
-				var x uint64
-				var shift uint
-				for i := 0; i < len(vb); i++ {
-					b := vb[i]
-					x |= uint64(b&0x7F) << shift
-					if (b & 0x80) == 0 {
-						break
-					}
-					shift += 7
+				if x, ok := tryUvarint(vb); ok {
+					sequences["last_code_id"] = x
+					changed = true
+					continue
 				}
-				sequences["last_code_id"] = x
-				changed = true
-				continue
 			}
 			continue
 		}
@@ -84,7 +107,37 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 			}
 		}
 
-		continue
+		kb, err := hex.DecodeString(w.Key)
+		if err != nil || len(kb) < 2 {
+			continue
+		}
+		if kb[0] == 0x06 {
+			addrLen := int(kb[1])
+			if addrLen > 0 && len(kb) >= 2+addrLen {
+				addrB := kb[2 : 2+addrLen]
+				addr, err := sdk.Bech32ifyAddressBytes("thor", addrB)
+				if err != nil || addr == "" {
+					continue
+				}
+				valAny := any(hex.EncodeToString(vb))
+				if len(vb) <= 10 {
+					if n, ok := tryUvarint(vb); ok {
+						valAny = n
+					}
+				}
+				if s := isPrintableUTF8(vb); s {
+					valAny = string(vb)
+				}
+				keyHex := hex.EncodeToString(kb[2+addrLen:])
+				kv := map[string]any{
+					"key_hex": keyHex,
+					"value":   valAny,
+				}
+				contractStates[addr] = append(contractStates[addr], kv)
+				changed = true
+				continue
+			}
+		}
 	}
 
 	if !changed {
@@ -102,6 +155,16 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 	}
 	if len(sequences) > 0 {
 		out["sequences"] = sequences
+	}
+	if len(contractStates) > 0 {
+		arr := make([]map[string]any, 0, len(contractStates))
+		for addr, kvs := range contractStates {
+			arr = append(arr, map[string]any{
+				"contract": addr,
+				"kv":       kvs,
+			})
+		}
+		out["contract_states"] = arr
 	}
 
 	if len(out) == 0 {

--- a/cmd/diff-api/aggregator/wasm.go
+++ b/cmd/diff-api/aggregator/wasm.go
@@ -12,8 +12,9 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 
 	codes := make([]map[string]any, 0)
 	contracts := make([]map[string]any, 0)
+	sequences := make(map[string]any)
+
 	paramsOut := make(map[string]any)
-	rawState := make([]map[string]string, 0)
 	changed := false
 
 	for _, w := range ws {
@@ -23,6 +24,26 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 		if w.Op == "delete" || w.Value == "" {
 			continue
 		}
+		if w.Key == "08" {
+			vb, err := base64.StdEncoding.DecodeString(w.Value)
+			if err == nil && len(vb) > 0 {
+				var x uint64
+				var shift uint
+				for i := 0; i < len(vb); i++ {
+					b := vb[i]
+					x |= uint64(b&0x7F) << shift
+					if (b & 0x80) == 0 {
+						break
+					}
+					shift += 7
+				}
+				sequences["last_code_id"] = x
+				changed = true
+				continue
+			}
+			continue
+		}
+
 		vb, err := base64.StdEncoding.DecodeString(w.Value)
 		if err != nil || len(vb) == 0 {
 			continue
@@ -63,11 +84,7 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 			}
 		}
 
-		rawState = append(rawState, map[string]string{
-			"key_hex":   w.Key,
-			"value_b64": w.Value,
-		})
-		changed = true
+		continue
 	}
 
 	if !changed {
@@ -83,9 +100,10 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 	if len(contracts) > 0 {
 		out["contracts"] = contracts
 	}
-	if len(rawState) > 0 {
-		out["raw_state"] = rawState
+	if len(sequences) > 0 {
+		out["sequences"] = sequences
 	}
+
 	if len(out) == 0 {
 		return nil, false
 	}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove `raw_state` fields across all aggregator modules

- Add proper decoding for bank metadata and params

- Expand thorchain aggregation to include nodes, vaults, LPs

- Enhance wasm contract state decoding with type inference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw KV Writes"] --> B["Aggregator Modules"]
  B --> C["Structured Decoding"]
  C --> D["Genesis-Ready Output"]
  E["raw_state removal"] --> F["Enhanced Type Support"]
  F --> G["Bank Metadata/Params"]
  F --> H["Thorchain Entities"]
  F --> I["Wasm Contract States"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>acc.go</strong><dd><code>Remove raw_state from account aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/acc.go

<ul><li>Remove <code>raw_state</code> collection and output<br> <li> Skip failed decoding instead of storing raw data<br> <li> Keep only successfully decoded account information</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/28/files#diff-a77e3231fca4f33e149189f66b3eae0f29d1090d281e6d59096c7d9a9f566613">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aggregator.go</strong><dd><code>Clean up main aggregator raw_state handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/aggregator.go

<ul><li>Remove <code>raw_state</code> handling from main aggregation logic<br> <li> Clean up auth module aggregation output</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/28/files#diff-42472900e0d9995116dea94f2d88066f1842cce00057eefcd68874ed3b96bda9">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bank.go</strong><dd><code>Add structured bank metadata and params decoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/bank.go

<ul><li>Replace <code>raw_state</code> with structured decoding<br> <li> Add denom metadata decoding (0x03 prefix)<br> <li> Add params decoding (0x11 prefix)<br> <li> Fix JSON conversion and output formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/28/files#diff-f041911acd79e691a4c0e328b1153eba75da5c267df6e8778b003043924650aa">+49/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>thorchain.go</strong><dd><code>Expand thorchain entity decoding coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/thorchain.go

<ul><li>Remove <code>raw_state</code> collection entirely<br> <li> Add node accounts, vaults, liquidity providers decoding<br> <li> Add outbound fees decoding with denom mapping<br> <li> Skip unknown prefixes instead of storing raw</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/28/files#diff-15ae52759e4dcb9e5e379a5a5fa4ff6498d486dddbe923ab7d55db1c374e0cc1">+110/-16</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wasm.go</strong><dd><code>Enhanced wasm contract state decoding with type inference</code></dd></summary>
<hr>

cmd/diff-api/aggregator/wasm.go

<ul><li>Remove <code>raw_state</code> and add contract state decoding<br> <li> Add <code>last_code_id</code> sequence decoding with uvarint<br> <li> Implement value type inference (varint/utf8/hex)<br> <li> Add contract-specific state grouping with 0x06 prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/28/files#diff-09a2a804bfea9fba41f0cf2255f7c09a08f985617edb97c9d1071032bb84a2fc">+89/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

