### PR TITLE
diff-api(wasm): fix 0x02/0x03 case scoping; ensure breaks and braces …

### DIFF
--- a/cmd/diff-api/aggregator/wasm.go
+++ b/cmd/diff-api/aggregator/wasm.go
@@ -1,6 +1,7 @@
 package aggregator
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -126,6 +127,49 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 					changed = true
 				}
 			}
+			break
+
+		case 0x03:
+			if len(kb) < 1+32 {
+				break
+			}
+			addrB := kb[1:33]
+			suffix := kb[33:]
+			addr, err := sdk.Bech32ifyAddressBytes("thor", addrB)
+			if err != nil || addr == "" {
+				break
+			}
+			if bytes.Equal(suffix, []byte("contract_info")) {
+				ci := new(wasmtypes.ContractInfo)
+				if appCodec.Unmarshal(vb, ci) != nil {
+					break
+				}
+			if jb, err := appCodec.MarshalJSON(ci); err == nil {
+				var mm map[string]any
+				if json.Unmarshal(jb, &mm) == nil {
+					agg := contractsByAddr[addr]
+					if agg == nil {
+						agg = &contractAgg{}
+						contractsByAddr[addr] = agg
+					}
+					agg.info = mm
+					changed = true
+				}
+			}
+			} else {
+				keyHex := hex.EncodeToString(suffix)
+				agg := contractsByAddr[addr]
+				if agg == nil {
+					agg = &contractAgg{}
+					contractsByAddr[addr] = agg
+				}
+				agg.state = append(agg.state, map[string]any{
+					"key":   keyHex,
+					"value": w.Value,
+				})
+				changed = true
+			}
+			break
 
 		case 0x06:
 			if len(kb) < 3 {
@@ -208,7 +252,7 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 					agg = &codeAgg{}
 					codesByID[id] = agg
 				}
-				agg.bytes = w.Value // keep original base64
+				agg.bytes = w.Value
 				changed = true
 			}
 
@@ -221,6 +265,40 @@ func aggregateWasm(ws []KVWrite) (map[string]any, bool) {
 				}
 				agg.pin = true
 				changed = true
+			}
+
+		case 0x09:
+			if len(kb) >= 1+32 {
+				addrB := kb[len(kb)-32:]
+				addr, err := sdk.Bech32ifyAddressBytes("thor", addrB)
+				if err == nil && addr != "" {
+					h := new(wasmtypes.ContractCodeHistoryEntry)
+					if appCodec.Unmarshal(vb, h) == nil {
+						if jb, err := appCodec.MarshalJSON(h); err == nil {
+							var mm map[string]any
+							if json.Unmarshal(jb, &mm) == nil {
+								agg := contractsByAddr[addr]
+								if agg == nil {
+                                    agg = &contractAgg{}
+                                    contractsByAddr[addr] = agg
+                                }
+								agg.history = append(agg.history, mm)
+								changed = true
+								break
+							}
+						}
+					}
+					var mm map[string]any
+					if json.Unmarshal(vb, &mm) == nil && len(mm) > 0 {
+						agg := contractsByAddr[addr]
+						if agg == nil {
+							agg = &contractAgg{}
+							contractsByAddr[addr] = agg
+						}
+						agg.history = append(agg.history, mm)
+						changed = true
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### **User description**
…so contract_info/state aggregation runs


___

### **PR Type**
Bug fix


___

### **Description**
- Fix case scoping issues in WASM aggregator switch statement

- Add missing break statements to prevent case fallthrough

- Implement 0x03 case for contract_info and state handling

- Add 0x09 case for contract code history processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WASM KV Processing"] --> B["Case 0x02: Contract Info"]
  A --> C["Case 0x03: Contract Info/State"]
  A --> D["Case 0x09: Code History"]
  B --> E["Add break statement"]
  C --> F["Handle contract_info suffix"]
  C --> G["Handle state data"]
  D --> H["Process history entries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wasm.go</strong><dd><code>Fix WASM aggregator case handling and scoping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/diff-api/aggregator/wasm.go

<ul><li>Add <code>bytes</code> import for byte comparison operations<br> <li> Fix missing break statement in case 0x02 to prevent fallthrough<br> <li> Implement complete case 0x03 handling for contract_info and state data<br> <li> Add case 0x09 for processing contract code history entries</ul>


</details>


  </td>
  <td><a href="https://github.com/0xBloctopus/thornode/pull/30/files#diff-09a2a804bfea9fba41f0cf2255f7c09a08f985617edb97c9d1071032bb84a2fc">+79/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

